### PR TITLE
fix the weights and jacobian for triangles, fix a bug in solve_mf()

### DIFF
--- a/framework/include/XFEM/XFEMMiscFuncs.h
+++ b/framework/include/XFEM/XFEMMiscFuncs.h
@@ -135,15 +135,15 @@ void static stdQuadr2D(unsigned int nen, unsigned int iord, std::vector<std::vec
       sg2[0][0] = 1.0/3.0;
       sg2[0][1] = 1.0/3.0;
       sg2[0][2] = 1.0/3.0;
-      sg2[0][3] = 1.0;
+      sg2[0][3] = 0.5;
     }
     else if (iord == 2) // three-point Gauss
     {
       sg2.resize(3);
       for (unsigned int i = 0; i < 3; ++i) sg2[i].resize(4);
-      sg2[0][0] = 2.0/3.0; sg2[0][1] = 1.0/6.0; sg2[0][2] = 1.0/6.0; sg2[0][3] = 1.0/3.0;
-      sg2[1][0] = 1.0/6.0; sg2[1][1] = 2.0/3.0; sg2[1][2] = 1.0/6.0; sg2[1][3] = 1.0/3.0;
-      sg2[2][0] = 1.0/6.0; sg2[2][1] = 1.0/6.0; sg2[2][2] = 2.0/3.0; sg2[2][3] = 1.0/3.0;
+      sg2[0][0] = 2.0/3.0; sg2[0][1] = 1.0/6.0; sg2[0][2] = 1.0/6.0; sg2[0][3] = 1.0/6.0;
+      sg2[1][0] = 1.0/6.0; sg2[1][1] = 2.0/3.0; sg2[1][2] = 1.0/6.0; sg2[1][3] = 1.0/6.0;
+      sg2[2][0] = 1.0/6.0; sg2[2][1] = 1.0/6.0; sg2[2][2] = 2.0/3.0; sg2[2][3] = 1.0/6.0;
     }
     else if (iord == 3) // four-point Gauss
     {
@@ -292,7 +292,7 @@ void static shapeFunc2D(unsigned int nen, std::vector<Real> &ss, std::vector<Poi
     Real xsjr = 1.0;
     if (xsj != 0.0)
         xsjr = 1.0/xsj;
-    xsj  *= 0.5;
+    // xsj  *= 0.5; // we do not have this 0.5 here because in stdQuad2D the sum of all weights in trig is 0.5
     shp[0][2] = ss[0];
     shp[1][2] = ss[1];
     shp[2][2] = ss[2];

--- a/framework/src/XFEM/XFEMCutElem2D.C
+++ b/framework/src/XFEM/XFEMCutElem2D.C
@@ -287,7 +287,7 @@ XFEMCutElem2D::solve_mf(unsigned int nen, unsigned int nqp, std::vector<Point> &
       wss[i].resize(4);
       wss[i][0] = _g_points[i](0);
       wss[i][1] = _g_points[i](1);
-      wss[i][2] = _g_points[i](2);
+      wss[i][2] = 1.0 - _g_points[i](0) - _g_points[i](1);
       wss[i][3] = _g_weights[i];
     }
   }else


### PR DESCRIPTION
I still haven't debugged the 2D pellet problem because it's a large-sized one. But in general, non-convergence is a result of clipped-off materials with non-fixed free DOFs. This may happen when two crack branches are too close or one single crack entangles itself. However, I did find two small bugs in your code for triangular elements. Please especially note the second bug -- I think _g_points[i][2], returned by libMesh, is always 0, so you have to get the real value of the third Gaussian point for a triangular element by 1-_g_points[i][0]-_g_points[i][1]. The first bug is easy to fix -- it's just the matter of where to put the 0.5 for a triangular element (either in the weights or in the jacobian).
